### PR TITLE
fix: Add missing ThemeBuilder export

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -29,4 +29,5 @@ export { AdvancedSearchManager } from './advanced-search';
 export { generatePrintStyles, addPrintUtilities, generatePrintPreview } from './print-styles';
 export { ThemeManager, type ThemePreset } from './theme-manager';
 export { ThemeSwitcher, type ThemeSwitcherOptions } from './theme-switcher';
+export { ThemeBuilder, type ThemeBuilderOptions } from './theme-builder';
 export { DarkModeToggle, type DarkModeToggleOptions } from './dark-mode-toggle';

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,7 @@ export { I18nManager, createI18nConfig, defaultMessages, createLocaleMessages } 
 export { TableOfContents, addHeadingIds } from './toc';
 export { AdvancedSearchManager } from './advanced-search';
 export { generatePrintStyles, addPrintUtilities, generatePrintPreview } from './print-styles';
+export { DarkModeToggle, type DarkModeToggleOptions } from './dark-mode-toggle';
+export { ThemeBuilder, type ThemeBuilderOptions } from './theme-builder';
 export { ThemeManager, type ThemePreset } from './theme-manager';
 export { ThemeSwitcher, type ThemeSwitcherOptions } from './theme-switcher';
-export { ThemeBuilder, type ThemeBuilderOptions } from './theme-builder';
-export { DarkModeToggle, type DarkModeToggleOptions } from './dark-mode-toggle';


### PR DESCRIPTION
## Summary

This PR adds the missing `ThemeBuilder` export to the library's main index file.

## Context

During testing of the theme switching functionality, I discovered that while `ThemeManager` and `ThemeSwitcher` were properly exported from the library, the `ThemeBuilder` class was missing from the exports. This prevented users from importing and using the ThemeBuilder for creating custom theme UIs.

## Changes

- Added `export { ThemeBuilder, type ThemeBuilderOptions } from './theme-builder';` to `src/index.ts`

## Impact

- Users can now import `ThemeBuilder` from the library: 
  ```typescript
  import { ThemeBuilder } from '@austinorphan/markdown-docs-viewer';
  ```
- Completes the theme management system exports alongside `ThemeManager` and `ThemeSwitcher`
- No breaking changes

## Testing

- ✅ Type checking passes (`npm run typecheck`)
- ✅ Linting passes
- ✅ Export verified in built library