### PR TITLE
fix: improve theme switcher cleanup on destroy

### DIFF
--- a/src/theme-switcher.ts
+++ b/src/theme-switcher.ts
@@ -705,7 +705,8 @@ export class ThemeSwitcher {
       backdrop.remove();
     }
 
-    // Clear container reference
+    // Remove container from DOM and clear reference
+    this.container?.remove();
     this.container = null;
     this.isOpen = false;
   }


### PR DESCRIPTION
## Summary

This PR extracts the meaningful theme-related improvement from the closed PR #48.

## Changes

- Ensures the theme switcher container is properly removed from the DOM when destroyed
- Adds `container.remove()` call in the destroy method to prevent memory leaks
- Provides complete cleanup when theme switcher is destroyed

## Context

This change was identified as the only substantial theme-related improvement from PR #48. The rest of that PR consisted of CI/build fixes that have already been resolved in main through other work.