### PR TITLE
Centralize escapeHtml utility across example files

### DIFF
--- a/examples/browser-usage.html
+++ b/examples/browser-usage.html
@@ -340,27 +340,12 @@ const advancedConfig = {
 
     <!-- Load the UMD build for examples -->
     <script src="../dist/index.umd.cjs"></script>
+    <!-- Load shared utilities -->
+    <script src="utils.js"></script>
 
     <script>
-      // Create triple backticks constant to avoid template literal parsing issues
-      const TRIPLE_BACKTICK = String.fromCharCode(96, 96, 96);
-
-      function showStatus(elementId, type, message) {
-        const statusEl = document.getElementById(elementId);
-        statusEl.className = `status ${type}`;
-        statusEl.textContent = message;
-        statusEl.style.display = 'block';
-      }
-
-      function escapeHtml(text) {
-        if (text == null) return '';
-        return String(text)
-          .replace(/&/g, '&amp;')
-          .replace(/</g, '&lt;')
-          .replace(/>/g, '&gt;')
-          .replace(/"/g, '&quot;')
-          .replace(/'/g, '&#039;');
-      }
+      // Use shared utilities
+      const { escapeHtml, showStatus, TRIPLE_BACKTICK } = window.ExampleUtils;
 
       function loadESModuleExample() {
         try {

--- a/examples/git-build-example.html
+++ b/examples/git-build-example.html
@@ -102,10 +102,12 @@
 
     <!-- Load the markdown docs viewer -->
     <script src="../dist/index.umd.cjs"></script>
+    <!-- Load shared utilities -->
+    <script src="utils.js"></script>
 
     <script>
-      // Create triple backticks constant to avoid template literal parsing issues
-      const TRIPLE_BACKTICK = String.fromCharCode(96, 96, 96);
+      // Use shared utilities
+      const { escapeHtml, TRIPLE_BACKTICK } = window.ExampleUtils;
 
       // Get the viewer classes from global
       const { MarkdownDocsViewer, defaultTheme, darkTheme } = window.MarkdownDocsViewer;
@@ -117,16 +119,6 @@
         const statusEl = document.getElementById('status');
         statusEl.className = `status ${type}`;
         statusEl.textContent = message;
-      }
-
-      function escapeHtml(text) {
-        if (text == null) return '';
-        return String(text)
-          .replace(/&/g, '&amp;')
-          .replace(/</g, '&lt;')
-          .replace(/>/g, '&gt;')
-          .replace(/"/g, '&quot;')
-          .replace(/'/g, '&#039;');
       }
 
       function destroyCurrentViewer() {

--- a/examples/theme-demo.html
+++ b/examples/theme-demo.html
@@ -107,10 +107,12 @@
 
     <!-- Load the viewer -->
     <script src="../dist/index.umd.cjs"></script>
+    <!-- Load shared utilities -->
+    <script src="utils.js"></script>
 
     <script>
-      // Create triple backticks constant to avoid template literal parsing issues
-      const TRIPLE_BACKTICK = String.fromCharCode(96, 96, 96);
+      // Use shared utilities
+      const { escapeHtml, TRIPLE_BACKTICK } = window.ExampleUtils;
 
       let viewer;
 
@@ -575,16 +577,6 @@ ${TRIPLE_BACKTICK}
                     <strong>Error:</strong> ${escapeHtml(error.message)}
                 </div>
             `;
-      }
-
-      function escapeHtml(text) {
-        if (text == null) return '';
-        return String(text)
-          .replace(/&/g, '&amp;')
-          .replace(/</g, '&lt;')
-          .replace(/>/g, '&gt;')
-          .replace(/"/g, '&quot;')
-          .replace(/'/g, '&#039;');
       }
 
       function showThemeInfo(message) {

--- a/examples/theming-demo.html
+++ b/examples/theming-demo.html
@@ -122,10 +122,12 @@
 
     <!-- Load the viewer -->
     <script src="../dist/index.umd.cjs"></script>
+    <!-- Load shared utilities -->
+    <script src="utils.js"></script>
 
     <script>
-      // Create triple backticks constant to avoid template literal parsing issues
-      const TRIPLE_BACKTICK = String.fromCharCode(96, 96, 96);
+      // Use shared utilities
+      const { escapeHtml, TRIPLE_BACKTICK } = window.ExampleUtils;
 
       let viewer;
 
@@ -592,16 +594,6 @@ ${TRIPLE_BACKTICK}
                     <strong>Error:</strong> ${escapeHtml(error.message)}
                 </div>
             `;
-      }
-
-      function escapeHtml(text) {
-        if (text == null) return '';
-        return String(text)
-          .replace(/&/g, '&amp;')
-          .replace(/</g, '&lt;')
-          .replace(/>/g, '&gt;')
-          .replace(/"/g, '&quot;')
-          .replace(/'/g, '&#039;');
       }
 
       function showThemeInfo(message) {

--- a/examples/utils.js
+++ b/examples/utils.js
@@ -1,0 +1,50 @@
+/**
+ * Shared utilities for Markdown Docs Viewer examples
+ *
+ * This file provides common utility functions used across example files
+ * to reduce code duplication and maintain consistency.
+ */
+
+(function () {
+  'use strict';
+
+  // Create namespace for example utilities
+  window.ExampleUtils = window.ExampleUtils || {};
+
+  /**
+   * Escapes HTML special characters to prevent XSS attacks
+   *
+   * @param {string|null|undefined} text - Text to escape
+   * @returns {string} HTML-escaped text
+   */
+  window.ExampleUtils.escapeHtml = function (text) {
+    if (text == null) return '';
+    return String(text)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#039;');
+  };
+
+  /**
+   * Shows a status message in a specific element
+   *
+   * @param {string} elementId - ID of the status element
+   * @param {string} type - Status type (success, error, warning, info)
+   * @param {string} message - Message to display
+   */
+  window.ExampleUtils.showStatus = function (elementId, type, message) {
+    const statusEl = document.getElementById(elementId);
+    if (statusEl) {
+      statusEl.className = `status ${type}`;
+      statusEl.textContent = message;
+      statusEl.style.display = 'block';
+    }
+  };
+
+  /**
+   * Creates triple backticks constant to avoid template literal parsing issues
+   */
+  window.ExampleUtils.TRIPLE_BACKTICK = String.fromCharCode(96, 96, 96);
+})();


### PR DESCRIPTION
## Summary

Addresses Issue #58 by centralizing the duplicated `escapeHtml` utility function across example files into a shared utility module.

## Changes Made

- **Created `examples/utils.js`** - Shared utility module with proper namespacing
- **Removed duplicate code** from 4 example files:
  - `examples/browser-usage.html`
  - `examples/git-build-example.html` 
  - `examples/theming-demo.html`
  - `examples/theme-demo.html`
- **Updated all files** to use `window.ExampleUtils.escapeHtml`
- **Added JSDoc comments** for better maintainability

## Benefits

✅ **Reduced Code Duplication** - Single source of truth for utility functions  
✅ **Better Maintainability** - Changes only need to be made in one place  
✅ **Consistent Implementation** - All files use the same escaping logic  
✅ **Clean Namespace** - Uses `window.ExampleUtils` to avoid global pollution  
✅ **Same Security** - Maintains XSS protection without functional changes  

## Testing

- All example files continue to use `escapeHtml()` for XSS protection
- Build process completes successfully
- No functional changes to security behavior

## Related

- Resolves #58
- Follow-up to security fixes in PR #57